### PR TITLE
Add Initial MongoDB Persistence; Closes #6

### DIFF
--- a/config
+++ b/config
@@ -1,0 +1,1 @@
+mongopath: mongodb://localhost/default

--- a/controllers/simulation.js
+++ b/controllers/simulation.js
@@ -1,0 +1,37 @@
+exports.install = function() {
+  F.restful('/simulations', [], simulation_query, simulation_get, simulation_save, simulation_delete);
+};
+
+function simulation_query() {
+  var self = this;
+  var Simulation = MODEL('simulation').Schema;
+
+  Simulation.find(function(err, docs) {
+    self.json(docs);
+  });
+}
+
+function simulation_get(id) {
+  var self = this;
+  var Simulation = MODEL('simulation').Schema;
+
+  Simulation.findById(id, function(err, doc) {
+    self.json(doc);
+  });
+}
+
+function simulation_save(id) {
+  var self = this;
+  var Simulation = MODEL('simulation').Schema;
+
+  Simulation.create({});
+  self.json({status: 'success'});
+}
+
+function simulation_delete(id) {
+  var self = this;
+  var Simulation = MODEL('simulation').Schema;
+
+  Simulation.findById(id).then((doc) => doc.remove());
+  self.json({status: 'success'});
+}

--- a/definitions/mongoose.js
+++ b/definitions/mongoose.js
@@ -1,0 +1,4 @@
+var mongoose = require('mongoose');
+mongoose.connect(F.config.mongopath);
+
+global.mongoose =  mongoose;

--- a/models/simulation.js
+++ b/models/simulation.js
@@ -1,0 +1,16 @@
+var mongoose = require('mongoose');
+var simulationSchema = mongoose.Schema({
+  bodies: [
+    {
+      position: {x: Number, y: Number},
+      velocity: {x: Number, y: Number},
+      mass: Number,
+      density: Number,
+      radius: Number,
+      luminosity: Number
+    }
+  ]
+});
+
+exports.name = 'simulation';
+exports.Schema = mongoose.model('Simulation', simulationSchema);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "homepage": "https://github.com/orbitable/mission-control#readme",
   "dependencies": {
+    "mongoose": "^4.4.3",
     "total.js": "^1.9.6"
   }
 }


### PR DESCRIPTION
Problem
-------

The back end should persist simulations states but it does not. This is because it
does not know how to connect to any database.

Solution
--------

Implement an initial persistence interface using MongoDB. There is a RESTful
HTTP interface defined in TotalJS which maps the appropriate HTTP requests to
model mutations using the Mongoose Mongo JS library. The rudimentary CRUD
operations are implemented but are far from safe/proper.

![1455507215](https://cloud.githubusercontent.com/assets/135916/13039286/629785d4-d35a-11e5-8221-70b1dd97e3ed.png)

Areas of Impact
---------------
- Persistence and Database
- Simulation Models

How to Test
-----------

- [ ] Install MongoDB and ensure it's listening on default ports on `localhost`
- [ ] Install the latests dependency updates `npm install`
- [ ] Start the back end server `node --harmony app.js`
- [ ] Make a request to [http://localhost:8000/simulations](http://localhost:8000/simulations)
- [ ] Use curl to make POST and DELETE HTTP requests to ensure they modify the
  back end collections.

References
----------
- /cc @dill-wood
- [GH Issue](https://github.com/orbitable/mission-control/issues/6)
- [Mongoose JS Library](http://mongoosejs.com/index.html)