### PR TITLE
Add CORS Configuration and Middleware; Closes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Ensure all dependencies are installed:
 npm install
 ```
 
-Run the debug server:
+Run the server locally:
 ```
-node --harmony app.js
+node --harmony debug.js
 ```
 

--- a/configs/mission-control-debug
+++ b/configs/mission-control-debug
@@ -1,0 +1,1 @@
+cors : http://localhost:8000,http://0.0.0.0:8000

--- a/configs/mission-control-release
+++ b/configs/mission-control-release
@@ -1,1 +1,2 @@
-mongopath     : mongodb://mongodb/default
+mongopath     : mongodb://mongo/default
+cors          : http://localhost:8000,http://0.0.0.0:8000,http://demo.orbitable.tech

--- a/controllers/simulation.js
+++ b/controllers/simulation.js
@@ -1,7 +1,7 @@
 var util = require('util');
 
 exports.install = function() {
-  F.restful('/simulations', [], simulation_query, simulation_get, simulation_save, simulation_delete);
+  F.restful('/simulations', ['#cors'], simulation_query, simulation_get, simulation_save, simulation_delete);
 };
 
 function simulation_query() {

--- a/definitions/orbitable-cors.js
+++ b/definitions/orbitable-cors.js
@@ -1,0 +1,23 @@
+var _ = require('lodash');
+
+/*
+ * Validates origin headers on requests and updates response.
+ *
+ * The cors middlewhere inspects the origin of all requests and compares
+ * them to a white list of comma seperated hosts. If a match is found the
+ * response includes an updated 'Access-Control-Allowed-Origin' header with
+ * the origin.
+ */
+F.middleware('cors', function(req, res, next, options, controller) {
+
+  if (controller) {
+    // Parse the cors field of the current config
+    var allowedOrigins = (F.config.cors || '').split(',');
+
+    // Validate request origin agains cors whitelist
+    var isOrigin = (uri) => uri === req.headers.origin;
+    controller.cors(_.find(allowedOrigins, isOrigin) || 'origin');
+  }
+
+  next();
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/orbitable/mission-control#readme",
   "dependencies": {
+    "lodash": "^4.5.1",
     "mongoose": "4.4.3",
     "total.js": "^1.9.6"
   }


### PR DESCRIPTION
Problem
=======

Mission control does not add allowed origin headers preventing API calls from
differing domains.

Solution
========

Add middleware to add headers when configuration permits an origin.

Howto Test
==========

- [ ] Run debug `node --harmony debug.js`
- [ ] Make an RESTful call from a non configured differing origin
- [ ] See allowed origin set to `origin`
- [ ] Make an RESTful call from allowed differing origin
- [ ] See allowed origin equal to differing origin