### PR TITLE
Expand Simulation API; Closes #21

### DIFF
--- a/configs/mission-control-test
+++ b/configs/mission-control-test
@@ -1,0 +1,4 @@
+mongopath     : mongodb://mongodb.orbitable.tech/default
+loglevel      : debug
+default-ip    : 127.0.0.1
+default-port  : 8001

--- a/controllers/simulation.js
+++ b/controllers/simulation.js
@@ -33,8 +33,10 @@ function simulation_delete(id) {
       return;
     }
 
-    self.throw404();
+    return self.throw404();
   });
+
+  return self.throw404();
 }
 
 function simulation_get(id) {
@@ -90,22 +92,29 @@ function simulation_save(id) {
   var Simulation = MODEL('simulation').schema;
 
   if (id) {
-    // TODO: Implement record updating
-    logger.warn("Updating a simulation is not implementend"); 
-    self.throw501();
-    return;
+    var updates = self.json;
+    logger.debug("Updating a simulation with id %s", id);
+
+    Simulation.findByIdAndUpdate(id, { $set: updates }, function(err, doc) {
+      if (err) {
+        logger.error("Unable to update simulation: %s", id, update);
+      }
+
+      self.json(doc);
+    });
+  } else {
+
+    logger.debug("Saving simulation id " + id);
+
+    Simulation.create(self.body, function(err, doc) {
+
+      if (err) {
+        logger.error("Unable to create simulation: " + err);
+        self.throw400(err);
+        return;
+      }
+
+      self.json(doc);
+    });
   }
-
-  logger.debug("Saving simulation id " + id);
-
-  Simulation.create(self.body, function(err, doc) {
-
-    if (err) {
-      logger.error("Unable to create simulation: " + err);
-      self.throw400(err);
-      return;
-    }
-
-    self.json(doc);
-  });
 }

--- a/tests/simulation.js
+++ b/tests/simulation.js
@@ -14,6 +14,7 @@
 
 var fakeId = '56ca44c0b61563713582121b';
 var testData = { bodies: [{ position: {x: 0, y: 0}, mass: 0}] };
+var testItem;
 
 exports.run = function() {
   F.assert('Simulation API GET', '/simulations', ['get'],  function(error, data, code, headers) {
@@ -28,15 +29,15 @@ exports.run = function() {
     assert.ok(code === 404, 'did not get 404 for non existent simulation');
   });
 
-  F.assert("Simulation API PUT missing position", "/simulations", ['post', 'json'], function(error, data, code, headers) {
+  F.assert("Simulation API POST missing position", "/simulations", ['post', 'json'], function(error, data, code, headers) {
     assert.ok(code == 400, 'did not get a bad request(400): ' + code);
   }, {bodies: [{mass: 12, radius: 1}]});
 
-  F.assert("Simulation API PUT missing mass", "/simulations", ['post', 'json'], function(error, data, code, headers) {
+  F.assert("Simulation API POST missing mass", "/simulations", ['post', 'json'], function(error, data, code, headers) {
     assert.ok(code == 400, 'did not get a bad request(400): ' + code);
   }, {bodies: [{position: {x: 0, y:0 }, radius: 1}]});
 
-  F.assert("Simulation API PUT", '/simulations', ['post', 'json'], function(error, data, code, headers) {
+  F.assert("Simulation API POST", '/simulations', ['post', 'json'], function(error, data, code, headers) {
     assert.ok(code == 200, 'did not get a success (200): (' + code + ') ' + error);
   }, testData );
 
@@ -44,5 +45,11 @@ exports.run = function() {
     assert.ok(code == 404, 'expected delete to return 404: ' + code);
   });
 
-  // TODO: Implement delete with a given id
+  F.assert('Simulation API DELETE', '/simulations/' + fakeId , ['delete', 'json'], function(error, data, code, headers) {
+    assert.ok(code == 404, 'expected delete to return 404; got ' + code);
+  });
+
+  F.assert('Simulation API PUT', '/simulations/' + fakeId, ['put', 'json'], function(error, data, code, headers) {
+    assert.ok(code == 404, 'expected put to return 200; got ' + code);
+  });
 };


### PR DESCRIPTION
Problem
=======

The simulations RESTful API is missing functionality to update exisiting
simulations objects as well as delete them.

Solution
========

Add the update and delete implementations to the restful controller.

Howto Test
==========

- [x] Confirm tests pass

/cc @dill-wood 