### PR TITLE
Add HTTPS Demo Origin

### DIFF
--- a/configs/mission-control-release
+++ b/configs/mission-control-release
@@ -1,3 +1,3 @@
 mongopath     : mongodb://mongo/default
-cors          : http://localhost:8000,http://0.0.0.0:8000,http://demo.orbitable.tech
+cors          : http://localhost:8000,http://0.0.0.0:8000,http://demo.orbitable.tech,https://demo.orbitable.tech
 loglevel      : notice


### PR DESCRIPTION
Problem
=======

The https origin for demo.orbitable.tech is not included in the release
configuration for mission-control. This prevents requests from including an
allowed origin and results in their failure.

Solution
========

Add `https://demo.orbitbable.tech` to the allowed origins for releases.

Howto Test
==========

**N/A**