### PR TITLE
Integrate Username/Password Validation; Closes #27 

### DIFF
--- a/controllers/session.js
+++ b/controllers/session.js
@@ -37,24 +37,66 @@ function session_delete(id) {
 
 
 function session_save(id) {
-  var self = this;
+    var self = this;
     logger.debug("Attempting to create new session...");
-  if (id) {
-
-    logger.debug("Updating a session with id %s", id);
+    if (id) {
+        logger.debug("Updating a session with id %s", id);
+    } else {
     //TODO: Add checks to credentials and throw error if checks invalid
     //return mock token if valid.
-
-  } else {
-    // TODO: Implement request data validation
-    var updates = {
-      _id: '1234567890abcdef',
-      token: 'aoiu4nb728ba2f',
-      timestamp: new Date() / 1000
-    };
-
     
-    self.json(updates);
+    //Populate schema with mock credentials first
+    var Session = MODEL('session').schema;
+    var m1 = MODEL('session').m1
+    var m2 = MODEL('session').m2
+    
+    //Add a couple of mock entries to populate our schema first
+    Session.create(m1, function(err, doc) {
+
+      if (err) {
+        logger.error("Unable to create session: " + err);
+        self.throw400(err);
+        return;
+      }
+
+      self.json(doc);
+    });
+        
+    Session.create(m2, function(err, doc) {
+
+      if (err) {
+        logger.error("Unable to create session: " + err);
+        self.throw400(err);
+        return;
+      }
+
+      self.json(doc);
+    });
+        
+        
+    //compare credentials from body to mock credentials
+    var Credentials = self.body
+    Session.find(Credentials, function(err, doc) {
+
+    if (err) {
+      logger.error("Encountered error finding username " + Credentials + ":" + err);
+      logger.debug(doc);
+      self.throw400();
+      return;
+    }
+
+    if (!doc) {
+      self.throw403();
+      return;
+    }
+    logger.debug(Credentials);
+    self.json(doc);
+    //Mock Token
+    var token = {tokenID : "13yasdd2245u67l"};
+    return token;
+  });
+    
+    
   }
 }
 

--- a/controllers/session.js
+++ b/controllers/session.js
@@ -14,100 +14,52 @@
 
 var util = require('util');
 
-
-
-
 exports.install = function () {
-    
   logger.debug("Installing session restful route");
-  F.restful('/sessions', [], not_allowed, not_allowed, session_save, session_delete);
+  F.restful('/sessions', ['post', 'json'], not_allowed, not_allowed, session_save, session_delete);
 };
 
 function not_allowed() {
-    logger.debug("Calling on un-implemeneted method");
-    var self = this;
-    self.status = 405;
-    return self.plain('');
+  logger.debug("Calling on un-implemeneted method");
+  var self = this;
+  self.status = 405;
+  return self.plain('');
 }
-
 
 function session_delete(id) {
-    logger.debug("Delete method not implemented. Throwing error");
-    var self = this;
-    return self.throw501();
-    
+  logger.debug("Delete method not implemented. Throwing error");
+  var self = this;
+  return self.throw501();
 }
 
-
-
 function session_save(id) {
-    var self = this;
-    logger.debug("Attempting to create new session...");
-    if (id) {
-        logger.debug("Updating a session with id %s", id);
-    } else {
-    //TODO: Add checks to credentials and throw error if checks invalid
-    //return mock token if valid.
-        
-    //Populate schema with mock credentials first
-    var Session = MODEL('session').schema;
-    var m1 = MODEL('session').m1
-    var m2 = MODEL('session').m2
-    
-    //Add a couple of mock entries to populate our schema first
-    Session.create(m1, function(err, doc) {
-        
-      if (err) {
-        logger.error("Unable to create session: " + err);
-        self.throw400(err);
-        return;
-      }
+  var self = this;
+  logger.debug("Attempting to create new session");
+  //TODO: Add checks to credentials and throw error if checks invalid
+  //return mock token if valid.
 
-      self.json(doc);
-    });
-        
-    Session.create(m2, function(err, doc) {
-        
-      if (err) {
-        logger.error("Unable to create session: " + err);
-        self.throw400(err);
-        return;
-      }
-        
-      self.json(doc);
-    });
-        
-        
-    //compare credentials from body to mock credentials
-    var Credentials = self.body
-    Session.find(Credentials, function(err, doc) {
-       
+  //Populate schema with mock credentials first
+  var Credential = MODEL('credential').schema;
+
+  //compare credentials from body to mock credentials
+  Credential.findOne({"username": self.body.username}, function(err, doc) {
+
     if (err) {
-      logger.error("Encountered error finding username " + Credentials + ":" + err);
-      self.throw400();
-      return;
+      logger.error("Encountered error finding username ", err);
+      return self.throw400();
     }
 
     if (!doc) {
-      self.status = 403;
-      return;
+      logger.debug("Did not find matching username " + self.body.username);
+      return self.throw403();
     }
-    
-    
-        //I know this doesnt work, just a placeholder
-    if (doc.username == Credentials.username && doc.password == Credentials.password) {
-        self.json(doc);
-        logger.debug(Credentials.username);
-        //Mock Token
-        var token = {tokenID : "13yasdd2245u67l"};
-        return token;
+
+    if (doc.password == self.body.password) {
+      var token = {tokenID : "13yasdd2245u67l"};
+      return self.json(token);
+    } else {
+      logger.debug("Invalid credentials");
+      return self.throw403();
     }
-        else{
-            logger.error("Invalid credentials");
-            self.status = 403;
-            return
-        }
-    
-    });
-}
+  });
 }

--- a/controllers/session.js
+++ b/controllers/session.js
@@ -42,7 +42,8 @@ function session_save(id) {
   if (id) {
 
     logger.debug("Updating a session with id %s", id);
-    //Add post information. STILL CONFUSED HOW TO SEND DATA WITHOUT IT! 
+    //TODO: Add checks to credentials and throw error if checks invalid
+    //return mock token if valid.
 
   } else {
     // TODO: Implement request data validation

--- a/controllers/session.js
+++ b/controllers/session.js
@@ -14,7 +14,11 @@
 
 var util = require('util');
 
+
+
+
 exports.install = function () {
+    
   logger.debug("Installing session restful route");
   F.restful('/sessions', [], not_allowed, not_allowed, session_save, session_delete);
 };
@@ -44,7 +48,7 @@ function session_save(id) {
     } else {
     //TODO: Add checks to credentials and throw error if checks invalid
     //return mock token if valid.
-    
+        
     //Populate schema with mock credentials first
     var Session = MODEL('session').schema;
     var m1 = MODEL('session').m1
@@ -52,7 +56,7 @@ function session_save(id) {
     
     //Add a couple of mock entries to populate our schema first
     Session.create(m1, function(err, doc) {
-
+        
       if (err) {
         logger.error("Unable to create session: " + err);
         self.throw400(err);
@@ -63,13 +67,13 @@ function session_save(id) {
     });
         
     Session.create(m2, function(err, doc) {
-
+        
       if (err) {
         logger.error("Unable to create session: " + err);
         self.throw400(err);
         return;
       }
-
+        
       self.json(doc);
     });
         
@@ -77,26 +81,33 @@ function session_save(id) {
     //compare credentials from body to mock credentials
     var Credentials = self.body
     Session.find(Credentials, function(err, doc) {
-
+       
     if (err) {
       logger.error("Encountered error finding username " + Credentials + ":" + err);
-      logger.debug(doc);
       self.throw400();
       return;
     }
 
     if (!doc) {
-      self.throw403();
+      self.status = 403;
       return;
     }
-    logger.debug(Credentials);
-    self.json(doc);
-    //Mock Token
-    var token = {tokenID : "13yasdd2245u67l"};
-    return token;
-  });
     
     
-  }
+        //I know this doesnt work, just a placeholder
+    if (doc.username == Credentials.username && doc.password == Credentials.password) {
+        self.json(doc);
+        logger.debug(Credentials.username);
+        //Mock Token
+        var token = {tokenID : "13yasdd2245u67l"};
+        return token;
+    }
+        else{
+            logger.error("Invalid credentials");
+            self.status = 403;
+            return
+        }
+    
+    });
 }
-
+}

--- a/models/credential.js
+++ b/models/credential.js
@@ -14,29 +14,11 @@
 
 var mongoose = require('mongoose');
 
-var body = mongoose.Schema({
-    username: {type: String, required: true},
-    password: {type: String, required: true}
+var Credential = mongoose.Schema({
+  username: {type: String, required: true, unique: true},
+  password: {type: String, required: true}
 });
 
-//TODO: Add fixture users for test logins
-
-var mockUser1 = {
-    username: 'Jerry',
-    password: 'jerry1'
-};
-
-var mockUser2 = {
-    username: 'Linda',
-    password: 'linda1'
-};
-
-
-
-
-exports.m1 = mockUser1;
-exports.m2 = mockUser2;
-exports.schema = mongoose.model('session', body);
-exports.name = 'session';
-
+exports.schema = mongoose.model('credential', Credential);
+exports.name = 'credential';
 

--- a/models/session.js
+++ b/models/session.js
@@ -11,7 +11,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-console.log("Start");
+
 var mongoose = require('mongoose');
 
 var body = mongoose.Schema({
@@ -33,7 +33,7 @@ var mockUser2 = {
 
 
 
-console.log("End");
+
 exports.m1 = mockUser1;
 exports.m2 = mockUser2;
 exports.schema = mongoose.model('session', body);

--- a/models/session.js
+++ b/models/session.js
@@ -11,6 +11,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
+console.log("Start");
 var mongoose = require('mongoose');
 
 var body = mongoose.Schema({
@@ -20,6 +21,22 @@ var body = mongoose.Schema({
 
 //TODO: Add fixture users for test logins
 
+var mockUser1 = {
+    username: 'Jerry',
+    password: 'jerry1'
+};
+
+var mockUser2 = {
+    username: 'Linda',
+    password: 'linda1'
+};
+
+
+
+console.log("End");
+exports.m1 = mockUser1;
+exports.m2 = mockUser2;
 exports.schema = mongoose.model('session', body);
 exports.name = 'session';
+
 

--- a/models/session.js
+++ b/models/session.js
@@ -1,0 +1,25 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+var mongoose = require('mongoose');
+
+var body = mongoose.Schema({
+    username: {type: String, required: true},
+    password: {type: String, required: true}
+});
+
+//TODO: Add fixture users for test logins
+
+exports.schema = mongoose.model('session', body);
+exports.name = 'session';
+

--- a/models/simulation.js
+++ b/models/simulation.js
@@ -59,7 +59,5 @@ Simulation.statics.random = function(count, mass, radius, spread) {
   });
 };
 
-
-
 exports.schema = mongoose.model('simulation', Simulation);
 exports.name = 'simulation';

--- a/models/simulation.js
+++ b/models/simulation.js
@@ -15,6 +15,7 @@
 var _        = require('lodash');
 var mongoose = require('mongoose');
 
+
 var Vector = new mongoose.Schema({x: {type: Number, default: 0}, y: {type: Number, default: 0}});
 
 Vector.statics.random = function(spread) {
@@ -57,6 +58,8 @@ Simulation.statics.random = function(count, mass, radius, spread) {
     bodies: _.range(count || 100).map(() => body.random(mass, radius, spread))
   });
 };
+
+
 
 exports.schema = mongoose.model('simulation', Simulation);
 exports.name = 'simulation';


### PR DESCRIPTION
# Problem
Even though our session endpoint is in place, we currently have no validation to verify username and password credentials.

# Solution
Add Username and Password validation to mission-control initially using mock un/pw combinations, and return a mock token to verify the authentication is working as intended.

# Acceptance Criteria


- [x] There should be a user model with a username and password

- [x] There should be a few fixture users to test logins with

- [x] A request with valid credentials should return a mock token

- [x] A request with invalid credentials should return an error with 403 Forbidden.