### PR TITLE
Add Luminosity to Random System Simulation; Closes #35

### DIFF
--- a/models/simulation.js
+++ b/models/simulation.js
@@ -76,7 +76,8 @@ var centerBody = function(mass, radius) {
         position: vector({x: 0, y: 0}),
         mass: mass,
         radius: radius,
-        density: 1410
+        density: 1410,
+        luminosity: _.sample(_.range(1,5))
     });
 };
 


### PR DESCRIPTION
Problem
=======

The random system generator does not give the center body a luminosity. This
prevents habitable zones from rendering.

Solution
========

Randomly generate a luminosity.

Howto Test
==========

- [ ] Tests pass