### PR TITLE
Update Configuration for Mongo; Closes #38

### DIFF
--- a/configs/mission-control
+++ b/configs/mission-control
@@ -1,4 +1,4 @@
-mongopath     : mongodb://mongodb.orbitable.tech/default
-loglevel      : debug
-default-ip    : 0.0.0.0
-default-port  : 8001
+mongoHost      : mongodb.orbitable.tech
+loglevel       : debug
+default-ip     : 0.0.0.0
+default-port   : 8001

--- a/configs/mission-control-debug
+++ b/configs/mission-control-debug
@@ -1,1 +1,5 @@
-cors : http://localhost:8000,http://0.0.0.0:8000
+mongoUser     : debug
+mongoPassword : debug
+mongoDatabase : debug
+cors      : http://localhost:8000,http://0.0.0.0:8000
+

--- a/configs/mission-control-release
+++ b/configs/mission-control-release
@@ -1,3 +1,4 @@
-mongopath     : mongodb://mongo/default
-cors          : http://localhost:8000,http://0.0.0.0:8000,http://demo.orbitable.tech,https://demo.orbitable.tech
-loglevel      : notice
+mongoHost     : mongo
+mongoDatabase : release
+cors           : http://localhost:8000,http://0.0.0.0:8000,http://demo.orbitable.tech,https://demo.orbitable.tech
+loglevel       : notice

--- a/configs/mission-control-test
+++ b/configs/mission-control-test
@@ -1,4 +1,6 @@
-mongopath     : mongodb://mongodb.orbitable.tech/default
+mongoUser     : test
+mongoPassword : test
+mongoDatabase : test
 loglevel      : debug
 default-ip    : 127.0.0.1
 default-port  : 8001

--- a/definitions/mongoose.js
+++ b/definitions/mongoose.js
@@ -13,6 +13,21 @@
  */
 
 var mongoose = require('mongoose');
-mongoose.connect(F.config.mongopath);
 
-global.mongoose =  mongoose;
+function mongooseUri(host, database, user, password) {
+  password = password === undefined ? '' : ':' + password;
+  user     = user     === undefined ? '' : user + password + '@';
+  database = database === undefined ? '' : database;
+
+  return "mongodb://" + user + host + "/" + database;
+}
+
+var host     = process.env.MONGO_HOST     || F.config.mongoHost     || 'localhost';
+var user     = process.env.MONGO_USER     || F.config.mongoUser;
+var password = process.env.MONGO_PASSWORD || F.config.mongoPassword;
+var database = process.env.MONGO_DATABASE || F.config.mongoDatabase || 'default';
+
+var mongoPath = mongooseUri(host, database, user, password);
+
+mongoose.connect(mongoPath);
+global.mongoose = mongoose;


### PR DESCRIPTION
Problem
=======

The configuration options for mongo are hard coded into the application. This
makes configuring the service at deploy time difficult, ie it is impossible at
the moment to give the service a private username and password to use with
production data.

Solution
========

Update the configuration process to accept environment variables. Then use this
parameterization to connect to the mongo database. The mongo database has been
configured to use authentication to prevent anonymous connections. This is a
preventative security measure given the service will hold authentication data.

Howto Test
==========

- [ ] Tests should pass
- [ ] Running `npm debug.js` should have no regressions