### PR TITLE
Add Users Endpoint; Closes #40

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 env:
   - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 language: node_js
 node_js:
   - 4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+env:
+  - CXX=g++-4.8
 language: node_js
 node_js:
   - 4.1

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,0 +1,52 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+var util = require('util');
+
+exports.install = function() {
+  logger.debug("Installing users restful route");
+
+  F.restful('/users', ['#cors'], methodNotAllowed, methodNotAllowed, user_save, methodNotAllowed); 
+};
+
+function methodNotAllowed() {
+  logger.debug("users: method not allowed");
+  this.status = 405;
+  return this.plain('405: Method not supported');
+}
+
+function user_save(id) {
+  var self = this;
+  var User = MODEL('user').schema;
+
+  if (id) {
+    // TODO: Implement user updates
+    return self.throw501();
+  } else {
+    logger.debug("users: creating new user");
+
+    User.create(self.body, function(err, doc) {
+
+      if (err) {
+        logger.error("users: unable to create new user: " + err);
+        // TODO: Do not return mongo err directly. Parse and identify reason for
+        // validation failure
+        self.throw400(err.message);
+        return;
+      }
+
+      self.json(doc);
+    });
+  }
+}

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,56 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+var mongoose = require('mongoose');
+var bcrypt   = require('bcrypt');
+
+var ROUNDS = 10;
+
+var UserSchema = new mongoose.Schema({
+  // TODO: Validate email format
+  username: {type: String, required: 'An username is required'},
+  email:    {type: String, required: 'An email address is required', trim: true, unique: true},
+  password: {type: String, select: false, required: 'A password is required'}
+});
+
+UserSchema.pre('save', function(next) {
+  var user = this;
+
+  if (!user.isModified('password')) return next();
+
+  bcrypt.genSalt(ROUNDS, function(err, salt) {
+    if (err) return next(err);
+
+    bcrypt.hash(user.password, salt, function(err, hash) {
+      if (err) return next(err);
+        
+      user.password = hash;
+      next();
+    });
+  });
+});
+
+UserSchema.methods.isValidPassword = function(givenPassword, callback) {
+  bcrypt.compare(givenPassword, this.password, cb);
+};
+
+UserSchema.methods.toJSON = function() {
+  var obj = this.toObject();
+  delete obj.password;
+  return obj;
+};
+
+exports.schema = mongoose.model('user', UserSchema);
+exports.name = 'user';
+

--- a/package.json
+++ b/package.json
@@ -12,12 +12,15 @@
     "url": "git+https://github.com/orbitable/mission-control.git"
   },
   "license": "Apache-2.0",
-  "contributors": ["Benjamin Campbell <benji@benjica.com>"],
+  "contributors": [
+    "Benjamin Campbell <benji@benjica.com>"
+  ],
   "bugs": {
     "url": "https://github.com/orbitable/mission-control/issues"
   },
   "homepage": "https://github.com/orbitable/mission-control#readme",
   "dependencies": {
+    "bcrypt": "^0.8.5",
     "lodash": "^4.5.1",
     "mongoose": "4.4.3",
     "total.js": "^1.9.6",

--- a/tests/1_users.js
+++ b/tests/1_users.js
@@ -1,0 +1,31 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+exports.run = function() {
+  F.assert('Getting users not supported', '/users', ['get'],  function(error, data, code, headers) {
+    assert.ok(code === 405, 'did not get 405');
+  });
+  F.assert('Deleting users is not supported', '/users/fake_id', ['delete'],  function(error, data, code, headers) {
+    assert.ok(code === 405, 'did not get 405');
+  });
+  F.assert('Getting user not supported', '/users/fake_id', ['get'],  function(error, data, code, headers) {
+    assert.ok(code === 405, 'did not get 405');
+  });
+  F.assert('Updating a user', '/users/123', ['put'], function(error, data, code, headers) {
+    assert.ok(code === 501, 'did not get a 501; Got ' + code);
+  }, {username: new Date(), password: new Date(), email: new Date()});
+  F.assert('Creating a user', '/users', ['post', 'json'], function(error, data, code, headers) {
+    assert.ok(code === 200, 'did not get a 200; Got ' + code);
+  }, {username: new Date(), password: new Date(), email: new Date()});
+};


### PR DESCRIPTION
Problem
=======

There is no way for users to register with the service.

Solution
========

Add a simple endpoint that allows user information to be registered.

Howto Test
==========

- [ ] Run this branch with `node debug.js`
- [ ] Make the following `POST` request
    - Set `Content-type: application/json` as a header
    - Include a json object as data with the following fields:
      ```javascript
      {
        "username": "TacoMan"
        "password": "SuperTaco1"
        "email": "tacoMan42@aol.com
      }
      ```
    - Confirm it returns a 200 status code with the same data **excluding** the
      password as a body.
- [ ] Attempt to make the same request and confirm it fails because of duplicate
  info.