### PR TITLE
Add Parameter Parsing; Closes #45

### DIFF
--- a/controllers/simulation.js
+++ b/controllers/simulation.js
@@ -74,25 +74,23 @@ function simulation_query() {
   });
 }
 
-function bigNum(b,e) {
-  return b * Math.pow(10,e);
-}
-
 function simulation_random() {
   logger.debug("Randomingly generating simulation");
 
   var self         = this;
-  var centerMass   = self.query.centerMass   || bigNum(1.988435,30);
-  var centerRadius = self.query.centerRadius || bigNum(6.955,8);
-  var count        = self.query.count        || 50;
-  var ringStep     = self.query.ringStep     || bigNum(0.3,11);
-  var bodyMass     = self.query.bodyMass     || bigNum(5.9721986,24);
-  var bodyRadius   = self.query.bodyRadius   || bigNum(6.3674447,6);
-  var chaos        = self.query.chaos        || 0.1;
+
+  // Query parameters are mapped to simulation generation || <default value>
+  var centerMass   = parseFloat(self.query.centerMass)    || 1.988435e30;
+  var centerRadius = parseFloat(self.query.centerRadius)  || 6.955e8;
+  var count        = parseInt(self.query.count)           || 50;
+  var ringStep     = parseFloat(self.query.ringStep)      || 0.3e11;
+  var bodyMass     = parseFloat(self.query.bodyMass)      || 5.9721986e24;
+  var bodyRadius   = parseFloat(self.query.bodyRadius)    || 6.3674447e6;
+  var chaos        = parseFloat(self.query.chaos)         || 0.1;
 
   var Simulation = MODEL('simulation').schema;
 
-  self.json(Simulation.randomSystem(centerMass,centerRadius,bodyCount,ringStep,bodyMass,bodyRadius,chaos));
+  self.json(Simulation.randomSystem(centerMass, centerRadius, count, ringStep, bodyMass, bodyRadius, chaos));
 }
 
 function simulation_save(id) {


### PR DESCRIPTION
Problem
-------

The random simulation endpoint has a bug where the simulation constructor is referencing an undefined variable.

Solution
--------

Update the ctor call to use the correct parameter name. In addition, this addes number parsing from the query string values as well as the use of scientific notation literals instead of bigNum utiltity function.

Howto Test
----------

- Run `node debug.js` to start service
- get [http://0.0.0.0:8001/simulations/random](http://0.0.0.0:8001/simulations/random)
  - Confirm default values are supplied
- get [http://0.0.0.0:8001/simulations/random?count=100](http://0.0.0.0:8001/simulations/random?count=100)
  - Confrim no errors with valid parameter value
- get [http://0.0.0.0:8001/simulations/random?bodyMass=tacobell](http://0.0.0.0:8001/simulations/random?bodyMass=tacobell)
  - Confirm bad parameter value reverts to default value

References
----------

- /cc @aaroncameron21