### PR TITLE
Web Token creation and verification

### DIFF
--- a/configs/mission-control-debug
+++ b/configs/mission-control-debug
@@ -1,5 +1,6 @@
 mongoUser     : debug
 mongoPassword : debug
 mongoDatabase : debug
+catchphrase : orbitableisfun
 cors      : http://localhost:8000,http://0.0.0.0:8000
 

--- a/controllers/session.js
+++ b/controllers/session.js
@@ -13,6 +13,7 @@
  */
 
 var util = require('util');
+var jwt = require('jsonwebtoken');
 
 exports.install = function () {
   logger.debug("Installing session restful route");
@@ -55,8 +56,11 @@ function session_save(id) {
     }
 
     if (doc.password == self.body.password) {
-      var token = {tokenID : "13yasdd2245u67l"};
-      return self.json(token);
+      //Utilize the jwt framework to handle token.
+        var token = jwt.sign(doc, config.catchphrase, {
+            expiresInMinutes: 1440 //just a default 24 hours
+        });
+        return self.json(token);
     } else {
       logger.debug("Invalid credentials");
       return self.throw403();

--- a/definitions/token.js
+++ b/definitions/token.js
@@ -1,0 +1,26 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+var jwt = require('jsonwebtoken');
+
+function checkToken(token, catchPhrase){
+    jwt.verify(token, catchPhrase, function(err, decoded){
+        if (err) {
+            logger.error("Failed to authenticate token");
+        } else {
+            //Need more insight here
+            next();
+        }
+    });
+    
+}


### PR DESCRIPTION
# Problem
We currently have no way of generating legitimate, unique tokens. Nor any way to verify if these tokens are valid
# Solution 
Add token creation and verification to back-end

# Acceptable Criteria

- [ ] Successfully create a token upon user login through the '/sessions' endpoint (should return the token through the API call)

- [ ] Get a 'valid' type response upon sending a token back through the '/users' endpoint (copying and pasting valid token from the first step, into the header for this step)