### PR TITLE
Use Username for User Collections Resource

### DIFF
--- a/configs/mission-control-debug
+++ b/configs/mission-control-debug
@@ -1,5 +1,5 @@
 mongoUser     : debug
 mongoPassword : debug
 mongoDatabase : debug
-cors      : http://localhost:8000,http://0.0.0.0:8000
-
+cors                   : http://localhost:8000,http://0.0.0.0:8000
+default-request-length : 1024

--- a/controllers/simulation.js
+++ b/controllers/simulation.js
@@ -88,7 +88,7 @@ function querySimulation(userId) {
     logger.debug('Getting simulations for user id ' + userId);
     var User = MODEL('user').schema;
 
-    User.findById(userId, function(err, user) {
+    User.find({$or: [{username: userId}]}, function(err, user) {
       if (err) {
         logger.error(err); return self.throw500(err);
       }
@@ -147,6 +147,8 @@ function saveSimulation(id) {
   var self = this;
   var Simulation = MODEL('simulation').schema;
 
+  logger.debug('saving simulation');
+
   if (id) {
     var updates = self.json;
     logger.debug('Updating a simulation with id %s', id);
@@ -159,8 +161,7 @@ function saveSimulation(id) {
       self.json(doc);
     });
   } else {
-
-    logger.debug('Saving simulation id ' + id);
+    logger.debug('Saving new simulation');
 
     Simulation.create(self.body, function(err, doc) {
 


### PR DESCRIPTION
Problem
-------

You must give the mongo id for a user when accessing the /users/<id>/simulations endpoint which is difficult to obtain.

Solution
--------

Use the alphanumeric username to reference the user in that resource url. This provides for friendlier urls when accessing user collections of simulations. This would prevent bridge from having to do some kind of lookup form a username to mongo id.

Howto Test
----------

- [ ] Existing test pass

References
----------

- [ ] Closes #57