### PR TITLE
Update All Configs to Allow 1MB Posts

### DIFF
--- a/configs/mission-control
+++ b/configs/mission-control
@@ -2,3 +2,4 @@ mongoHost      : mongodb.orbitable.tech
 loglevel       : debug
 default-ip     : 0.0.0.0
 default-port   : 8001
+default-request-length : 1024

--- a/configs/mission-control-debug
+++ b/configs/mission-control-debug
@@ -2,4 +2,3 @@ mongoUser     : debug
 mongoPassword : debug
 mongoDatabase : debug
 cors                   : http://localhost:8000,http://0.0.0.0:8000
-default-request-length : 1024


### PR DESCRIPTION
Problem
-------

The default request length is 5kb which prevents a large POST request of 50 bodies from succeeding. This is overridden for debug mode when running mission-control locally but was not overridden for release environments.

Solution
--------

Apply the con fig to the global configuration file.

Howto Test
----------

- [ ] Existing test pass

References
----------

- Closes #60 