### PR TITLE
Correct User Filtered Queries

### DIFF
--- a/controllers/simulation.js
+++ b/controllers/simulation.js
@@ -87,14 +87,14 @@ function querySimulation(userId) {
     logger.debug('Getting simulations for user id ' + userId);
     var User = MODEL('user').schema;
 
-    User.find({$or: [{username: userId}]}, function(err, user) {
+    User.findOne({username: userId}, function(err, u) {
       if (err) {
         logger.error(err); return self.throw500(err);
       }
 
-      if (!user) { return self.throw404(user); }
+      if (!u) { return self.throw404(u); }
 
-      Simulation.find({createdBy: user._id}, function(err, simulations) {
+      Simulation.find({createdBy: u._id}, function(err, simulations) {
         if (err) {
           logger.error(err); return self.throw500(err);
         }


### PR DESCRIPTION
Problem
-------

Whenever a simulation query with a userId specified no associated
simulations are found. This is because it was using a general find query.

Solution
--------

Use a singular `findOne` query to simplify the user id query to the first
matching instance.

Howto Test
----------

- This is tested in cordination with a Bridge PR to add user based lists

References
----------

- Closes #61